### PR TITLE
expose inner SSH client and status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { SocksClient, SocksClientOptions } from 'socks';
 import logger from './logger';
 import { getAvailablePort } from './utils';
 
-enum STATUS {
+export enum STATUS {
   INIT = 0,
   CONNECTING,
   READY,
@@ -480,6 +480,13 @@ class SshTunnel {
     }
     const targetList = this.proxyList.filter(item => id ? item.id === id : true);
     targetList.forEach(item => item.server.close());
+  }
+
+  getSSHClient(): SshClient | undefined  {
+    return this.sshClient
+  }
+  getSocksStatus(): STATUS {
+    return this.socksStatus
   }
 
 }


### PR DESCRIPTION
can you expose the status and SSH2 inner client?
this would be really helpful for tracking when the status of the underlying connection